### PR TITLE
server: fix getting current logs as txt

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -75,6 +75,7 @@ func main() {
 	r.HandleFunc("/{channel:[a-zA-Z0-9_-]+ chatlog}/premium/{nick:[a-zA-Z0-9_-]{1,25}}/{month:[a-zA-Z]+ [0-9]{4}}", d.WatchHandle("PremiumUser", PremiumUserHandle)).Methods("GET")
 	r.HandleFunc("/Destinygg chatlog/current", d.WatchHandle("DestinyBase", DestinyBaseHandle)).Methods("GET")
 	r.HandleFunc("/Destinygg chatlog/current/{nick:[a-zA-Z0-9_]+}", d.WatchHandle("DestinyNick", DestinyNickHandle)).Queries("search", "{filter:.+}").Methods("GET")
+	r.HandleFunc("/Destinygg chatlog/current/{nick:[a-zA-Z0-9_]+}.txt", d.WatchHandle("DestinyNick", DestinyNickHandle)).Methods("GET")
 	r.HandleFunc("/Destinygg chatlog/current/{nick:[a-zA-Z0-9_]+}", d.WatchHandle("DestinyNick", DestinyNickHandle)).Methods("GET")
 	r.HandleFunc("/Destinygg chatlog/{month:[a-zA-Z]+ [0-9]{4}}/broadcaster.txt", d.WatchHandle("DestinyBroadcaster", DestinyBroadcasterHandle)).Methods("GET")
 	r.HandleFunc("/Destinygg chatlog/{month:[a-zA-Z]+ [0-9]{4}}/broadcaster", d.WatchHandle("DestinyBroadcaster", DestinyBroadcasterHandle)).Methods("GET")


### PR DESCRIPTION
Given these two URLs:

  1) https://overrustlelogs.net/Destinygg%20chatlog/February%202016/userlogs/Destiny
  2) https://dgg.overrustlelogs.net/Destiny

Both (1) and (2) appear to display the same log. If I add `.txt` to end of each of them:

  3) https://overrustlelogs.net/Destinygg%20chatlog/February%202016/userlogs/Destiny.txt
  4) https://dgg.overrustlelogs.net/Destiny.txt

(3) is a text file whilst (4) is an error. I would expect (4) to be a text file just as (3) is.

This patch _might_ fix this. I admit I have not tested it locally. If this is not the correct fix for this then feel free to close and author a proper fix, or guide me in adjusting this PR accordingly.
