### PR TITLE
Vagrant + .local.conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vagrant
+/package/etc/overrustlelogs/overrustlelogs.local.conf
 *.swp
 logger/logger.exe
 *.sublime-project

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vagrant
 *.swp
 logger/logger.exe
 *.sublime-project

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,25 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below.
+Vagrant.configure(2) do |config|
+  config.vm.box = "driebit/debian-8-x86_64"
+  config.vm.hostname = "overrustlelogs"
+
+  config.vm.network "forwarded_port", guest: 80, host: 2780
+  config.vm.network "forwarded_port", guest: 8080, host: 2788
+  config.vm.network "forwarded_port", guest: 22, host: 2755
+
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = 4069
+    vb.cpus = 3
+  end
+
+  config.vm.provision "provision", type: "shell", inline: "cd /vagrant; pwd; echo 'running ./scripts/vagrant-provision.sh'; bash ./scripts/vagrant-provision.sh"
+
+  config.vm.provision "build-helper", type: "shell", inline: "echo '#!/bin/bash' > /home/vagrant/env.sh; echo 'sudo sh -c '\\''cd /vagrant; exec \"${SHELL:-sh}\"'\\''' >> /home/vagrant/env.sh; chmod +x /home/vagrant/env.sh"
+
+  config.vm.provision "update", type: "shell", run: "always", inline: "cd /vagrant; pwd; echo 'running ./scripts/update.sh local'; bash ./scripts/update.sh local"
+
+end

--- a/package/etc/overrustlelogs/systemd.conf
+++ b/package/etc/overrustlelogs/systemd.conf
@@ -1,0 +1,1 @@
+DAEMON_OPTS="-config=/etc/overrustlelogs/overrustlelogs.conf"

--- a/package/etc/systemd/system/orl-bot.service
+++ b/package/etc/systemd/system/orl-bot.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Overrustlelogs Bot-Part
+After=network.target
+
+[Service]
+User=overrustlelogs
+Restart=always
+EnvironmentFile=/etc/overrustlelogs/systemd.conf
+PIDFile=/var/run/orl-bot.pid
+ExecStart=/usr/bin/orl-bot $DAEMON_OPTS
+
+[Install]
+WantedBy=multi-user.target

--- a/package/etc/systemd/system/orl-logger.service
+++ b/package/etc/systemd/system/orl-logger.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Overrustlelogs Logger-Part
+After=network.target
+
+[Service]
+User=overrustlelogs
+Restart=always
+EnvironmentFile=/etc/overrustlelogs/systemd.conf
+PIDFile=/var/run/orl-logger.pid
+ExecStart=/usr/bin/orl-logger $DAEMON_OPTS
+
+[Install]
+WantedBy=multi-user.target

--- a/package/etc/systemd/system/orl-server.service
+++ b/package/etc/systemd/system/orl-server.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Overrustlelogs Server-Part
+After=network.target
+
+[Service]
+User=overrustlelogs
+Restart=always
+EnvironmentFile=/etc/overrustlelogs/systemd.conf
+PIDFile=/var/run/orl-server.pid
+ExecStart=/usr/bin/orl-server $DAEMON_OPTS
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -22,6 +22,9 @@ cp -r $GOPATH/src/$src/server/assets /var/overrustlelogs/public/assets
 chown -R overrustlelogs:overrustlelogs /var/overrustlelogs/views
 chown -R overrustlelogs:overrustlelogs /var/overrustlelogs/public/assets
 cp -r $GOPATH/src/$src/package/* /
+if [ -f "$GOPATH/src/$src/package/etc/overrustlelogs/overrustlelogs.local.conf" ]; then
+	cp -p "$GOPATH/src/$src/package/etc/overrustlelogs/overrustlelogs.local.conf" /etc/overrustlelogs/overrustlelogs.conf
+fi
 chown -R overrustlelogs:overrustlelogs /var/overrustlelogs
 
 mkdir -p /var/nginx/cache

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -27,6 +27,13 @@ chown -R overrustlelogs:overrustlelogs /var/overrustlelogs
 mkdir -p /var/nginx/cache
 chown -R www-data:www-data /var/nginx
 
+## systemd support
+if [ -z `which start` ]; then
+	SSS="systemctl "
+else
+	SSS=""
+fi
+
 echo "next steps:"
 echo "1.) add creds to /etc/overrustlelogs/overrustlelogs.conf"
-echo "2.) run $ start logger && start server"
+echo "2.) run $ ${SSS}start logger && ${SSS}start server"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -58,6 +58,13 @@ updateLogger(){
 	echo "updated the orl-logger"
 }
 
+updatePack(){
+	cp -r $GOPATH/src/$src/package/* /
+	chown -R overrustlelogs:overrustlelogs /var/overrustlelogs
+	systemctl daemon-reload
+	echo "updated package etc & var"
+}
+
 if [[ $TODO == "bot" ]]; then
 	echo "updating the orl-bot..."
 	updateBot
@@ -67,6 +74,9 @@ elif [[ $TODO == "server" ]]; then
 elif [[ $TODO == "logger" ]]; then
 	echo "updating the orl-logger"
 	updateLogger
+elif [[ $TODO == "pack" ]]; then
+	echo "updating package etc & var"
+	updatePack
 else
 	echo "updating everything..."
 	updateBot

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -4,22 +4,29 @@ export src="github.com/slugalisk/overrustlelogs"
 
 git pull
 
+## systemd support
+if [ -z `which start` ]; then
+	SSS=systemctl
+else
+	SSS=
+fi
+
 source /etc/profile
 
 updateBot(){
 	go install $src/bot
 
-	stop orl-bot
+	$SSS stop orl-bot
 	
 	cp $GOPATH/bin/bot /usr/bin/orl-bot
 	
-	start orl-bot
+	$SSS start orl-bot
 	echo "updated the orl-bot"
 }
 
 updateServer(){
 	go install $src/server
-	stop orl-server
+	$SSS stop orl-server
 
 	cp -r $GOPATH/src/$src/server/views /var/overrustlelogs/
 	cp -r $GOPATH/src/$src/server/assets /var/overrustlelogs/public/
@@ -28,7 +35,7 @@ updateServer(){
 
 	cp $GOPATH/bin/server /usr/bin/orl-server
 
-	start orl-server
+	$SSS start orl-server
 	echo "updated the orl-server"
 }
 
@@ -36,12 +43,12 @@ updateLogger(){
 	go install $src/logger
 	go install $src/tool
 
-	stop orl-logger
+	$SSS stop orl-logger
 
 	cp $GOPATH/bin/logger /usr/bin/orl-logger
 	cp $GOPATH/bin/tool /usr/bin/orl-tool
 
-	start orl-logger
+	$SSS start orl-logger
 	echo "updated the orl-logger"
 }
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -2,7 +2,13 @@
 
 export src="github.com/slugalisk/overrustlelogs"
 
-git pull
+## local mode to deploy ignoring git
+if [[ $1 == "local" ]]; then
+	TODO=$2
+else
+	TODO=$1
+	git pull
+fi
 
 ## systemd support
 if [ -z `which start` ]; then
@@ -52,13 +58,13 @@ updateLogger(){
 	echo "updated the orl-logger"
 }
 
-if [[ $1 == "bot" ]]; then
+if [[ $TODO == "bot" ]]; then
 	echo "updating the orl-bot..."
 	updateBot
-elif [[ $1 == "server" ]]; then
+elif [[ $TODO == "server" ]]; then
 	echo "updating the orl-server..."
 	updateServer
-elif [[ $1 == "logger" ]]; then
+elif [[ $TODO == "logger" ]]; then
 	echo "updating the orl-logger"
 	updateLogger
 else

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -62,6 +62,10 @@ updateLogger(){
 
 updatePack(){
 	cp -r $GOPATH/src/$src/package/* /
+	if [ -f "$GOPATH/src/$src/package/etc/overrustlelogs/overrustlelogs.local.conf" ]; then
+		echo "NOTICE: found overrustlelogs.local.conf, overwriting default file..."
+		cp -p "$GOPATH/src/$src/package/etc/overrustlelogs/overrustlelogs.local.conf" /etc/overrustlelogs/overrustlelogs.conf
+	fi
 	chown -R overrustlelogs:overrustlelogs /var/overrustlelogs
 	systemctl daemon-reload
 	echo "updated package etc & var"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -5,8 +5,10 @@ export src="github.com/slugalisk/overrustlelogs"
 ## local mode to deploy ignoring git
 if [[ $1 == "local" ]]; then
 	TODO=$2
+	MODE=local
 else
 	TODO=$1
+	MODE=default
 	git pull
 fi
 
@@ -79,6 +81,14 @@ elif [[ $TODO == "pack" ]]; then
 	updatePack
 else
 	echo "updating everything..."
+	if [[ $MODE == "local" ]]; then
+		echo
+		echo "NOTE, local mode will replace etc with the pack!!!"
+		sleep 3
+		echo "..."
+		sleep 2
+		updatePack
+	fi
 	updateBot
 	updateLogger
 	updateServer

--- a/scripts/vagrant-provision.sh
+++ b/scripts/vagrant-provision.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+export base=`dirname $0`
+bash "$base/all.sh"
+
+rm /etc/nginx/sites-enabled/default
+/etc/init.d/nginx restart
+
+echo
+echo "PROVISIONER -- enabling all services for you on default..."
+systemctl enable orl-logger
+systemctl enable orl-server
+systemctl enable orl-bot


### PR DESCRIPTION
Implemented Vagrant 
- added needed hooks for systemd (debian8)
- runs `update local` from the local-repository on every boot,
- update via `vagrant provision --provision-with=update`
- see via `http://127.0.0.1:2780/` AND/OR `vagrant ssh -c ./env.sh`

New "update.sh" flags:
- added flag `local` to skip the 'git pull'
- added target `pack` to repopulate /etc/ from the repo into the Vagrant VM
- if existent /etc/overrustlelogs/overrustlelogs.conf will be overwritten by the '.local.conf' version of it!

Do NOT edit /etc/\* directly on the VM. 
Copy `package/e/o/overrustlelogs.conf` to `package/e/o/overrustlelogs.local.conf`! 
Update && install will populate this version over overrustlelogs.conf
