### PR TITLE
new twitch chat servers (aws)

### DIFF
--- a/package/etc/overrustlelogs/overrustlelogs.conf
+++ b/package/etc/overrustlelogs/overrustlelogs.conf
@@ -15,8 +15,8 @@
     }
   },
   "twitch": {
-    "socketURL": "ws://irc.twitch.tv:80/ws",
-    "originURL": "http://irc.twitch.tv",
+    "socketURL": "ws://irc-ws.chat.twitch.tv:80/ws",
+    "originURL": "http://irc-ws.chat.twitch.tv",
     "nick": "",
     "oauth": "",
     "admins": [


### PR DESCRIPTION
Twitch: PSA: Chat servers are going to migrate to AWS EC2 servers
https://discuss.dev.twitch.tv/t/psa-chat-servers-are-going-to-migrate-to-aws-ec2-servers/4877/48
